### PR TITLE
Automatically run tests on code change

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ You can run webserver and see your changes live in your web browser:
 
   1. You should fill code in `exercises` directory and run tests to see if you did everything right.
   2. You must do exercises in given order.
-  3. Try to not peak tests files! They contain spoilers.
-  4. To run tests, use `npm run test-es6`
+  3. Try to not peek at the tests files! They contain spoilers.
+  4. To run tests, use `npm run test-es6`. To automatically run tests when your code changes, use `npm run watch`.
 
 ## Additional resources
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "setup": "scripts/setup.sh",
     "start": "./node_modules/nodemon/bin/nodemon.js server.js",
-    "test-es6": "jsx -x jsx --es6module exercises/es6 src/es6 >/dev/null && mocha -b --compilers js:mocha-traceur -r test/es6/helpers.js test/es6/**/*.js ; true"
+    "test-es6": "jsx -x jsx --es6module exercises/es6 src/es6 >/dev/null && mocha -b --compilers js:mocha-traceur -r test/es6/helpers.js test/es6/**/*.js ; true",
+    "watch": "onchange exercises/es6/*.jsx -- npm run test-es6"
   },
   "repository": {
     "type": "git",
@@ -24,18 +25,19 @@
   },
   "homepage": "https://github.com/arkency/reactjs_koans",
   "devDependencies": {
-    "express": "^4.12.4",
-    "jsdom": "^3.1.2",
-    "mocha": "^2.2.4",
-    "mocha-traceur": "^2.1.0",
-    "react": "^0.13.3",
-    "react-tools": "^0.13.3",
-    "react-hot-loader": "^1.2.3",
-    "lodash": "^3.8.0",
     "babel-core": "^5.5.1",
     "babel-loader": "^5.1.3",
+    "express": "^4.12.4",
+    "jsdom": "^3.1.2",
+    "lodash": "^3.8.0",
+    "mocha": "^2.2.4",
+    "mocha-traceur": "^2.1.0",
+    "nodemon": "^1.3.7",
+    "onchange": "^1.1.0",
+    "react": "^0.13.3",
+    "react-hot-loader": "^1.2.3",
+    "react-tools": "^0.13.3",
     "webpack": "^1.9.10",
-    "webpack-dev-server": "^1.9.0",
-    "nodemon": "^1.3.7"
+    "webpack-dev-server": "^1.9.0"
   }
 }


### PR DESCRIPTION
Using "onchange", we can run the `test-es6` script when code changes. 

Demo screencast (30 seconds): http://screencast.com/t/FXmiEWKu