### PR TITLE
Clarify componentDidMount()

### DIFF
--- a/koans/es6/07-LifecycleMethods.js.jsx
+++ b/koans/es6/07-LifecycleMethods.js.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 //
 // There are three methods that are widely used:
 // * componentDidMount - this method fires when React component is rendered for
-//                       the first time.
+//                       the first time on the client.
 //                       A render can be caused by an explicit React.render
 //                       call or when a child component is rendered within a render
 //                       method of its parent component.


### PR DESCRIPTION
`componentDidMount()` only is called on the client. Server-side react using `React.renderToString()` will not call it.

https://facebook.github.io/react/docs/component-specs.html#mounting-componentwillmount