### PR TITLE
Fix exercise numbering for Lifecycle Method tests

### DIFF
--- a/test/es6/07-LifecycleMethods.js
+++ b/test/es6/07-LifecycleMethods.js
@@ -1,7 +1,7 @@
 import LifecycleMethodsComponent from '../../src/es6/07-LifecycleMethods.js';
 import sinon from 'sinon';
 
-describe("06 - Lifecycle methods", () => {
+describe("07 - Lifecycle methods", () => {
   var component;
 
   describe("Task #1 - emit a console log when the component mounts", () => {


### PR DESCRIPTION
It was confusing to see:

1) 06 - Lifecycle methods Task #1 - emit a console log when the component mounts should emit 'I'm mounted!' in developer's console:

Since this is not a part of Exercise 6.