### PR TITLE
Updated git clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Koans are a set of tasks to complete. Prepared tests checks if they are done
 
 ## Installation
 
-  1. `git clone git@github.com:arkency/reactjs_koans.git`
+  1. `git clone https://github.com/arkency/reactjs_koans.git`
   2. `cd reactjs_koans` 
   3. `npm run setup`
 


### PR DESCRIPTION
Copying your original script didn't work for me using Mac OSX and terminal. Issue was resolved by using https instead of git
Is there an appropriate catch-all for using git vs https where appropriate?

Here was the error message I got:
git clone git@github.com:arkency/reactjs_koans.git
Cloning into 'reactjs_koans'...
Warning: Permanently added the RSA host key for IP address '192.30.252.130' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.