### PR TITLE
Use lastest version of jsdom to fix build issues with newer versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-core": "^5.6.15",
     "babel-loader": "^5.3.1",
     "express": "^4.12.4",
-    "jsdom": "^3.1.2",
+    "jsdom": "^6.5.1",
     "lodash": "^3.8.0",
     "mocha": "^2.2.4",
     "ncp": "^2.0.0",


### PR DESCRIPTION
I was having similar issues as the ones detailed here https://github.com/arkency/reactjs_koans/issues/45.  The issue is directly related to the contextify package that jsdom was using.  The latest version no longer uses that package (https://github.com/tmpvar/jsdom/issues/1188)